### PR TITLE
Fix IPv4/IPv6 test method calls

### DIFF
--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -415,19 +415,19 @@ class Test_Connections_for_IPv4(_TestConnections, unittest.IsolatedAsyncioTestCa
         return await super().test_single_connections()
 
     async def test_multiple_connections(self):
-        return await super().test_single_connections()
+        return await super().test_multiple_connections()
 
     async def test_disconnection(self):
-        return await super().test_single_connections()
+        return await super().test_disconnection()
 
     async def test_edges_disconnection(self):
-        return await super().test_single_connections()
+        return await super().test_edges_disconnection()
 
     async def test_edges_client_orphan(self):
-        return await super().test_single_connections()
+        return await super().test_edges_client_orphan()
 
     async def test_edges_server_orphan(self):
-        return await super().test_single_connections()
+        return await super().test_edges_server_orphan()
 
     async def test_response_udp(self):
         return await super().test_response_udp()
@@ -488,19 +488,19 @@ class Test_Connections_for_IPv6(unittest.IsolatedAsyncioTestCase, _TestConnectio
         return await super().test_single_connections()
 
     async def test_multiple_connections(self):
-        return await super().test_single_connections()
+        return await super().test_multiple_connections()
 
     async def test_disconnection(self):
-        return await super().test_single_connections()
+        return await super().test_disconnection()
 
     async def test_edges_disconnection(self):
-        return await super().test_single_connections()
+        return await super().test_edges_disconnection()
 
     async def test_edges_client_orphan(self):
-        return await super().test_single_connections()
+        return await super().test_edges_client_orphan()
 
     async def test_edges_server_orphan(self):
-        return await super().test_single_connections()
+        return await super().test_edges_server_orphan()
 
     async def test_response_udp(self):
         return await super().test_response_udp()


### PR DESCRIPTION
## Summary
- update IPv4 and IPv6 connection tests to invoke correct base methods

## Testing
- `pip install cryptography nest_asyncio`
- `pytest -q test/test_connection.py::Test_Connections_for_IPv4::test_multiple_connections -s` *(fails: SystemExit 1)*

------
https://chatgpt.com/codex/tasks/task_e_683f7cc36e30832db3f3dd2d2631bb59